### PR TITLE
Replace hardcoded path by variables and add python3.9 compatibility

### DIFF
--- a/core/class/teleo.class.php
+++ b/core/class/teleo.class.php
@@ -196,8 +196,8 @@ class teleo extends eqLogic {
 			return null;
 		  }
 		  
-		  $cmdBash = system::getCmdSudo() . '/var/www/html/plugins/teleo/resources/get_veolia_data.sh ' . $veoliaWebsite . ' \'' . $login . '\' "' . $password . '" ' . $dataDirectory . ' ' . $logLevel . ' ' . $contractID;
-		  
+		  $cmdBash = system::getCmdSudo() . ' ' . realpath(dirname(__FILE__) . '/../../resources/get_veolia_data.sh') . ' ' . $veoliaWebsite . ' \'' . $login . '\' "' . $password . '" ' . $dataDirectory . ' ' . $logLevel . ' ' . $contractID;
+
 		  log::add(__CLASS__, 'debug', $this->getHumanName() . ' Commande : ' . $cmdBash);
 		  $output = shell_exec($cmdBash);
 

--- a/resources/get_veolia_data.sh
+++ b/resources/get_veolia_data.sh
@@ -17,14 +17,14 @@ else
 fi
 
 # Setup
-root='/var/www/html/plugins/teleo/resources'
+root=$(dirname -- "${BASH_SOURCE}")
 python="python3"
 timeout=180
 
 # Check Python version
 if [ "$1" = "IDF" ]; then
-	if [ $($python --version 2>&1 | grep -c 'Python 3.7.') == "0" ]; then
-		echo "Python version must be 3.7.x"
+	if [ $($python --version 2>&1 | grep -Ec 3\.(7|9)\.) == "0" ]; then
+		echo "Python version must be 3.7.x or 3.9.x"
 		exit 0
 	fi
 elif [ "$1" = "Other" ]; then


### PR DESCRIPTION
Hi,

This plugin doesn't work if jeedom is not installed in default path. I fixed it.

Maybe I missed something but I tested with python 3.9 and all seems to work as expected.